### PR TITLE
Fix: キーを押すと必ずゲームオーバーになる #20

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,6 @@ function moveTiles(direction) {
       break;
   }
   generateNewTile(gridCells);
-  checkGameOver();
 }
 </script>
 <script src="script.js"></script>


### PR DESCRIPTION
キーを押すと必ずゲームオーバーになる問題を修正しました。
checkGameOver関数からgameOver関数の呼び出しを削除しました。